### PR TITLE
Overridden listener methods support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-.metadata/**
-.recommenders/**
-.settings/**
-.idea/**
-bin/**
-target/**
+.metadata/
+.recommenders/
+.settings/
+.idea/
+bin/
+target/
 
+*___jb_*___
 *.iml
 
 .classpath

--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ See: [Recaf](https://github.com/Col-E/Recaf)
 ### Using in your project
 
 This project is hosted via JitPack.io. You can add this project to your maven project like so:
-```
+```xml
 <repositories>
-	<repository>
-	    <id>jitpack.io</id>
-	    <url>https://jitpack.io</url>
-	</repository>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
 </repositories>
 <dependencies>
-	<dependency>
-	    <groupId>com.github.Col-E</groupId>
-	    <artifactId>Events</artifactId>
-	    <version>1.3</version>
-	</dependency>
+    <dependency>
+        <groupId>com.github.Col-E</groupId>
+        <artifactId>Events</artifactId>
+        <version>1.4</version>
+    </dependency>
 </dependencies>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.coley</groupId>
 	<artifactId>events</artifactId>
-	<version>1.3</version>
+	<version>1.4</version>
 	<name>Events</name>
 	<description>Basic event handling library</description>
 	<!-- -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<jmh.version>1.21</jmh.version>
+		<proguard.version>6.0.3</proguard.version>
+		<jdk.library.path>${java.home}/lib/rt.jar</jdk.library.path>
 	</properties>
 	<build>
 		<plugins>
@@ -23,8 +25,78 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.wvengen</groupId>
+				<artifactId>proguard-maven-plugin</artifactId>
+				<version>2.0.14</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>proguard</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<proguardVersion>${proguard.version}</proguardVersion>
+					<includeDependencyInjar>true</includeDependencyInjar>
+					<addMavenDescriptor>true</addMavenDescriptor>
+					<injar>${project.build.finalName}.jar</injar>
+					<outjar>${project.build.finalName}.jar</outjar>
+					<libs>
+						<lib>${jdk.library.path}</lib>
+					</libs>
+					<options>
+						<option>-dontshrink</option>
+						<option>-dontobfuscate</option>
+						<option>-optimizations code/*</option>
+						<option>-optimizationpasses 5</option>
+						<option>-keepnames class *</option>
+						<option>-keepattributes *</option>
+						<option>-dontwarn java.lang.invoke.MethodHandle</option>
+						<option>-dontnote jdk.internal.**</option>
+					</options>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>net.sf.proguard</groupId>
+						<artifactId>proguard-base</artifactId>
+						<version>${proguard.version}</version>
+						<scope>runtime</scope>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>com.coderplus.maven.plugins</groupId>
+				<artifactId>copy-rename-maven-plugin</artifactId>
+				<version>1.0.1</version>
+				<executions>
+					<execution>
+						<id>rename-file</id>
+						<phase>package</phase>
+						<goals>
+							<goal>rename</goal>
+						</goals>
+						<configuration>
+							<sourceFile>${project.build.directory}/${project.build.finalName}_proguard_base.jar</sourceFile>
+							<destinationFile>${project.build.directory}/${project.build.finalName}-original.jar</destinationFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>jdk9+</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<jdk.library.path>${java.home}/jmods/java.base.jmod</jdk.library.path>
+			</properties>
+		</profile>
+	</profiles>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/me/coley/event/AccessHelper.java
+++ b/src/main/java/me/coley/event/AccessHelper.java
@@ -30,14 +30,14 @@ final class AccessHelper {
 
 	/**
 	 * Indicate whether we should try to bypass access control using {@code setAccessible(true)}.
-	 * Testing purpose only.
+	 * For testing purpose only.
 	 */
 	static boolean trySuppressAccessControl = true;
 
-	/** Indicate whether we should pretend we are running on Java 1.8. Testing purpose only. */
+	/** Indicate whether we should pretend we are running on Java 1.8. For testing purpose only. */
 	static boolean pretendJava8 = false;
 
-	/** Indicate whether we should pretend we are running on Java 9. Testing purpose only. */
+	/** Indicate whether we should pretend we are running on Java 9. For testing purpose only. */
 	static boolean pretendJava9 = false;
 
 	static {
@@ -286,7 +286,6 @@ final class AccessHelper {
 	 */
 	@SuppressWarnings({ "ManualArrayToCollectionCopy", "UseBulkOperation" })
 	public static List<Method> getMethodsRecursively(Class<?> cls) throws SecurityException {
-		// Uses custom identity function for overriden method handling
 		class MethodWrapper {
 			final Method method;
 			final String name;
@@ -300,6 +299,7 @@ final class AccessHelper {
 				this.returnType = method.getReturnType();
 			}
 
+			// Uses custom identity function for overriden method handling
 			@Override
 			public boolean equals(Object o) {
 				if (this == o) return true;

--- a/src/main/java/me/coley/event/AccessHelper.java
+++ b/src/main/java/me/coley/event/AccessHelper.java
@@ -291,12 +291,15 @@ final class AccessHelper {
 			final String name;
 			final Class<?>[] paramTypes;
 			final Class<?> returnType;
+			final boolean canOverride;
 
 			MethodWrapper(Method method) {
 				this.method = method;
 				this.name = method.getName();
 				this.paramTypes = method.getParameterTypes();
 				this.returnType = method.getReturnType();
+				int modifiers = method.getModifiers();
+				this.canOverride = !Modifier.isStatic(modifiers) && !Modifier.isFinal(modifiers);
 			}
 
 			// Uses custom identity function for overriden method handling
@@ -309,7 +312,10 @@ final class AccessHelper {
 						Arrays.equals(paramTypes, that.paramTypes) &&
 						// Java language doesn't allow overloading with different return type,
 						// but bytecode does. So let's check it anyway.
-						Objects.equals(returnType, that.returnType);
+						Objects.equals(returnType, that.returnType) &&
+						// If either of the two methods are static or final, check declaring class as well
+						((canOverride && that.canOverride) ||
+								Objects.equals(method.getDeclaringClass(), that.method.getDeclaringClass()));
 			}
 
 			@Override

--- a/src/main/java/me/coley/event/Bus.java
+++ b/src/main/java/me/coley/event/Bus.java
@@ -16,7 +16,8 @@ public final class Bus {
 	 *
 	 * @param object object whose listener methods should be registered
 	 * @param lookup the {@linkplain MethodHandles.Lookup Lookup object} used in {@link MethodHandle} creation
-	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object}
+	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object},
+	 *                                  or the {@code object} doesn't have any listener methods
 	 * @throws SecurityException        if a security manager denied access to the declared methods
 	 *                                  of the class of the {@code object}, or the provided
 	 *                                  {@linkplain MethodHandles.Lookup lookup object}
@@ -33,7 +34,8 @@ public final class Bus {
 	 * Registers all listener methods on {@code object} for receiving events.
 	 *
 	 * @param object object whose listener methods should be registered
-	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object}
+	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object},
+	 *                                  or the {@code object} doesn't have any listener methods
 	 * @throws SecurityException        if a security manager denied access to the declared methods
 	 *                                  of the class of the {@code object}, or the default
 	 *                                  {@linkplain MethodHandles.Lookup lookup object} cannot access

--- a/src/main/java/me/coley/event/EventBus.java
+++ b/src/main/java/me/coley/event/EventBus.java
@@ -141,15 +141,18 @@ public class EventBus {
 			throw new IllegalArgumentException("Needs @Listener annotation: " + method.toGenericString());
 		}
 
-		if (Modifier.isStatic(method.getModifiers())) {
+		int modifiers = method.getModifiers();
+		if (Modifier.isStatic(modifiers)) {
 			throw new IllegalArgumentException("Method cannot be static: " + method.toGenericString());
 		}
+		if (Modifier.isAbstract(modifiers)) {
+			throw new IllegalArgumentException("Method cannot be abstract: " + method.toGenericString());
+		}
 
-		Class<?>[] params = method.getParameterTypes();
-		if (params.length != 1) {
+		if (method.getParameterCount() != 1) {
 			throw new IllegalArgumentException("Must have exactly one parameter: " + method.toGenericString());
 		}
-		if (!Event.class.isAssignableFrom(params[0])) {
+		if (!Event.class.isAssignableFrom(method.getParameterTypes()[0])) {
 			throw new IllegalArgumentException("Parameter must be a subclass of the Event class: " + method.toGenericString());
 		}
 	}
@@ -160,10 +163,13 @@ public class EventBus {
 	 * @return {@code true} if it is, {@code false} otherwise
 	 */
 	public static boolean isListenerMethod(Method method) {
-		if (!AccessHelper.isAnnotationPresentRecursively(method, Listener.class) ||
-				Modifier.isStatic(method.getModifiers())) return false;
-		Class<?>[] params = method.getParameterTypes();
-		return params.length == 1 && Event.class.isAssignableFrom(params[0]);
+		if (AccessHelper.isAnnotationPresentRecursively(method, Listener.class) &&
+				method.getParameterCount() == 1 &&
+				Event.class.isAssignableFrom(method.getParameterTypes()[0])) {
+			int modifiers = method.getModifiers();
+			return !Modifier.isStatic(modifiers) && !Modifier.isAbstract(modifiers);
+		}
+		return false;
 	}
 
 	/**

--- a/src/main/java/me/coley/event/EventBus.java
+++ b/src/main/java/me/coley/event/EventBus.java
@@ -94,8 +94,7 @@ public class EventBus {
 	 * @param event event to post
 	 */
 	public void post(Event event) {
-		handlerRegistry.getHandler(Objects.requireNonNull(event, "event").getClass())
-				.post(event);
+		handlerRegistry.getHandler(event.getClass()).post(event);
 	}
 
 	/**

--- a/src/main/java/me/coley/event/EventBus.java
+++ b/src/main/java/me/coley/event/EventBus.java
@@ -215,6 +215,7 @@ public class EventBus {
 	/**
 	 * Event distribution handler.
 	 */
+	@SuppressWarnings("VolatileArrayField")
 	static class Handler {
 		/**
 		 * Event type for this handler.
@@ -238,13 +239,11 @@ public class EventBus {
 		/**
 		 * Cache for the {@link #supertypeHandlers} field.
 		 */
-		@SuppressWarnings("VolatileArrayField")
 		private transient volatile Object[] supertypeHandlerCache = null;
 
 		/**
 		 * Cache for the {@link #invokers} field.
 		 */
-		@SuppressWarnings("VolatileArrayField")
 		private transient volatile Object[] invokerCache = null;
 
 		Handler(Class<? extends Event> eventType) { this.eventType = eventType; }
@@ -278,16 +277,16 @@ public class EventBus {
 			if (hasSupertypeHandler()) {
 				// Prevent ConcurrentModificationException
 				// in cases where a registered item may register more items.
-				Object[] handlerArray = supertypeHandlerCache;
-				if (handlerArray == null) {
+				Object[] cache = supertypeHandlerCache;
+				if (cache == null) {
 					synchronized (this) {
-						if ((handlerArray = supertypeHandlerCache) == null) {
-							handlerArray = supertypeHandlerCache = supertypeHandlers.toArray();
+						if ((cache = supertypeHandlerCache) == null) {
+							cache = supertypeHandlerCache = supertypeHandlers.toArray();
 						}
 					}
 				}
 
-				for (Object handler : handlerArray) {
+				for (Object handler : cache) {
 					((Handler) handler).invoke(event);
 				}
 			}
@@ -299,16 +298,16 @@ public class EventBus {
 		void invoke(Event event) {
 			// Prevent ConcurrentModificationException
 			// in cases where a registered item may register more items.
-			Object[] invokerArray = invokerCache;
-			if (invokerArray == null) {
+			Object[] cache = invokerCache;
+			if (cache == null) {
 				synchronized (this) {
-					if ((invokerArray = invokerCache) == null) {
-						invokerArray = invokerCache = invokers.toArray();
+					if ((cache = invokerCache) == null) {
+						cache = invokerCache = invokers.toArray();
 					}
 				}
 			}
 
-			for (Object invoker : invokerArray) {
+			for (Object invoker : cache) {
 				((InvokeWrapper) invoker).invoke(event);
 			}
 		}

--- a/src/main/java/me/coley/event/EventBus.java
+++ b/src/main/java/me/coley/event/EventBus.java
@@ -32,7 +32,8 @@ public class EventBus {
 	 *
 	 * @param object object whose listener methods should be registered
 	 * @param lookup the {@linkplain MethodHandles.Lookup Lookup object} used in {@link MethodHandle} creation
-	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object}
+	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object},
+	 *                                  or the {@code object} doesn't have any listener methods
 	 * @throws SecurityException        if a security manager denied access to the declared methods
 	 *                                  of the class of the {@code object}, or the provided
 	 *                                  {@linkplain MethodHandles.Lookup lookup object}
@@ -48,6 +49,9 @@ public class EventBus {
 		}
 
 		Set<InvokeWrapper> invokers = getInvokers(object, lookup);
+		if(invokers.isEmpty()) {
+			throw new IllegalArgumentException("the object doesn't have any listener methods");
+		}
 		listenerToInvokers.put(object, invokers);
 		for (InvokeWrapper invoker : invokers) {
 			handlerRegistry.getHandler(invoker.eventType).subscribe(invoker);
@@ -58,7 +62,8 @@ public class EventBus {
 	 * Registers all listener methods on {@code object} for receiving events.
 	 *
 	 * @param object object whose listener methods should be registered
-	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object}
+	 * @throws IllegalArgumentException if there's an invalid listener method on the {@code object},
+	 *                                  or the {@code object} doesn't have any listener methods
 	 * @throws SecurityException        if a security manager denied access to the declared methods
 	 *                                  of the class of the {@code object}, or the default
 	 *                                  {@linkplain MethodHandles.Lookup lookup object} cannot access

--- a/src/main/java/me/coley/event/Listener.java
+++ b/src/main/java/me/coley/event/Listener.java
@@ -1,15 +1,14 @@
 package me.coley.event;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotation for methods indicating the method should receive events.
  *
  * @author Matt
  */
+@Documented
+@Inherited  // @Inherited doesn't work for method, so we have to implement that manually anyway...
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Listener {

--- a/src/test/java/me/coley/event/AccessHelperTest.java
+++ b/src/test/java/me/coley/event/AccessHelperTest.java
@@ -2,6 +2,8 @@ package me.coley.event;
 
 import me.coley.event.testevent.TestAlphaEvent;
 import me.coley.event.testevent.TestBetaEvent;
+import me.coley.event.testevent.TestDeltaEvent;
+import me.coley.event.testevent.TestZetaEvent;
 import org.junit.*;
 
 import java.lang.invoke.MethodHandles;
@@ -94,7 +96,10 @@ public class AccessHelperTest {
 		assertEqualsIgnoreOrder("getMethodsRecursively(InheritanceTestSampleC.class)", Arrays.asList(
 				"InheritanceTestSampleC.onEvent(TestBetaEvent)",
 				"InheritanceTestSampleB.onEvent(Event)",
-				"InheritanceTestSampleA.onAlphaEvent(TestAlphaEvent)"),
+				"InheritanceTestSampleB.onEvent(TestDeltaEvent)",
+				"InheritanceTestSampleA.onAlphaEvent(TestAlphaEvent)",
+				"InheritanceTestSampleA.onZetaEvent(TestZetaEvent)",
+				"InheritanceTestSampleA.onEvent(TestDeltaEvent)"),
 				mapMethodToName(methods));
 	}
 
@@ -139,8 +144,16 @@ public class AccessHelperTest {
 			fail("InheritanceTestSampleA.onAlphaEvent(TestAlphaEvent) called");
 		}
 
+		public final void onZetaEvent(TestZetaEvent event) {
+			fail("InheritanceTestSampleA.onZetaEvent(TestZetaEvent) called");
+		}
+
 		public void onEvent(TestBetaEvent event) {
 			fail("InheritanceTestSampleA.onEvent(TestBetaEvent) called");
+		}
+
+		public static void onEvent(TestDeltaEvent event) {
+			fail("InheritanceTestSampleA.onEvent(TestDeltaEvent) called");
 		}
 
 		public void onEvent(Event event) {
@@ -152,6 +165,10 @@ public class AccessHelperTest {
 		@Override
 		public void onEvent(Event event) {
 			fail("InheritanceTestSampleB.onEvent(Event) called");
+		}
+
+		public static void onEvent(TestDeltaEvent event) {
+			fail("InheritanceTestSampleB.onEvent(TestDeltaEvent) called");
 		}
 	}
 

--- a/src/test/java/me/coley/event/AccessHelperTest.java
+++ b/src/test/java/me/coley/event/AccessHelperTest.java
@@ -1,0 +1,164 @@
+package me.coley.event;
+
+import me.coley.event.testevent.TestAlphaEvent;
+import me.coley.event.testevent.TestBetaEvent;
+import org.junit.*;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+/**
+ * @author Andy Li
+ */
+public class AccessHelperTest {
+	@Test
+	// suppress warning for when compiling with Java 9+ (isAccessible() method is deprecated since Java 9)
+	@SuppressWarnings("deprecation")
+	public void testTrySetAccessible() throws ReflectiveOperationException {
+		assumeTrue("trySetAccessible() only available to Java 9 or higher", AccessHelper.isAtLeastJava9());
+		Method method = MemberClassA.class.getDeclaredMethod("privateMethod");
+		assertFalse("method shouldn't accessible yet", method.isAccessible());
+		assertTrue("trySetAccessible() returns false", AccessHelper.trySetAccessible(method));
+		assertTrue("method should be accessible after trySetAccessible() returns true", method.isAccessible());
+	}
+
+	@Test
+	public void testNarrowLookupClass() throws ReflectiveOperationException {
+		MethodHandles.Lookup lookup = MethodHandles.lookup().in(AccessHelperTest.class);
+		Method method = MemberClassA.class.getDeclaredMethod("privateMethod");
+
+		MethodHandles.Lookup newLookup = AccessHelper.narrowLookupClass(lookup, method);
+		assertEquals("lookupClass should change to MemberClassA", MemberClassA.class, newLookup.lookupClass());
+		assertEquals("lookupModes shouldn't change", lookup.lookupModes(), newLookup.lookupModes());
+	}
+
+	@Test
+	public void testNarrowLookupClass2() throws ReflectiveOperationException {
+		MethodHandles.Lookup lookup = MethodHandles.lookup().in(MemberClassB.MemberClassC.class);
+		Method method = MemberClassB.class.getDeclaredMethod("protectedMethod");
+
+		MethodHandles.Lookup newLookup = AccessHelper.narrowLookupClass(lookup, method);
+		assertEquals("lookupClass should change to MemberClassB", MemberClassB.class, newLookup.lookupClass());
+		assertEquals("lookupModes shouldn't change", lookup.lookupModes(), newLookup.lookupModes());
+	}
+
+	@Test
+	public void testNarrowLookupClass3() throws ReflectiveOperationException {
+		MethodHandles.Lookup lookup = MethodHandles.lookup().in(MemberClassA.class);
+		Method method = PackageListener.MemberClass.class.getDeclaredMethod("foo");
+
+		MethodHandles.Lookup newLookup = AccessHelper.narrowLookupClass(lookup, method);
+		assertEquals("lookupClass shouldn't change", lookup.lookupClass(), newLookup.lookupClass());
+		assertEquals("lookupModes shouldn't change", lookup.lookupModes(), newLookup.lookupModes());
+	}
+
+	@Test
+	public void testGetOutermostEnclosingClass() {
+		assertEquals("MemberClassA's outermost enclosing class", AccessHelperTest.class,
+				AccessHelper.getOutermostEnclosingClass(MemberClassA.class));
+		assertEquals("MemberClassC's outermost enclosing class", AccessHelperTest.class,
+				AccessHelper.getOutermostEnclosingClass(MemberClassB.MemberClassC.class));
+		assertEquals("PackageListener.MemberClass's outermost enclosing class", PackageListener.class,
+				AccessHelper.getOutermostEnclosingClass(PackageListener.MemberClass.class));
+	}
+
+	@Test
+	public void testIsSamePackage() {
+		assertTrue("Number and Integer should be in the same package",
+				AccessHelper.isSamePackage(Number.class, Integer.class));
+		assertTrue("Method and Field should be in the same package",
+				AccessHelper.isSamePackage(Method.class, Field.class));
+		assertFalse("List and Object shouldn't be in the same package",
+				AccessHelper.isSamePackage(List.class, Object.class));
+	}
+
+	@Test
+	public void testIsSamePackageMember() {
+		assertTrue("MemberClassA and MemberClassB should be nestmate",
+				AccessHelper.isSamePackageMember(MemberClassA.class, MemberClassB.class));
+		assertFalse("MemberClassA and PackageListener.MemberClass shouldn't be nestmate",
+				AccessHelper.isSamePackageMember(MemberClassA.class, PackageListener.MemberClass.class));
+	}
+
+	@Test
+	public void testGetMethodsRecursively() {
+		List<Method> methods = AccessHelper.getMethodsRecursively(InheritanceTestSampleC.class);
+		assertEqualsIgnoreOrder("getMethodsRecursively(InheritanceTestSampleC.class)", Arrays.asList(
+				"InheritanceTestSampleC.onEvent(TestBetaEvent)",
+				"InheritanceTestSampleB.onEvent(Event)",
+				"InheritanceTestSampleA.onAlphaEvent(TestAlphaEvent)"),
+				mapMethodToName(methods));
+	}
+
+	private static List<String> mapMethodToName(List<Method> methods) {
+		return methods.stream()
+				.map(method -> String.format("%s.%s(%s)",
+						method.getDeclaringClass().getSimpleName(),
+						method.getName(),
+						Arrays.stream(method.getParameterTypes())
+								.map(Class::getSimpleName)
+								.collect(Collectors.joining(", "))))
+				.collect(Collectors.toList());
+	}
+
+	private static <T> void assertEqualsIgnoreOrder(String message, Collection<T> expected, Collection<T> actual) {
+		if (expected == actual) return;
+		if (expected.size() != actual.size() || !expected.containsAll(actual)) {
+			assertEquals(message, expected, actual);
+		}
+	}
+
+	static class MemberClassA {
+		private void privateMethod() {
+			fail("privateMethod() called");
+		}
+	}
+
+	static class MemberClassB {
+		protected void protectedMethod() {
+			fail("protectedMethod() called");
+		}
+
+		static class MemberClassC {
+			public void foo() {
+				fail("foo() called");
+			}
+		}
+	}
+
+	static class InheritanceTestSampleA {
+		public void onAlphaEvent(TestAlphaEvent event) {
+			fail("InheritanceTestSampleA.onAlphaEvent(TestAlphaEvent) called");
+		}
+
+		public void onEvent(TestBetaEvent event) {
+			fail("InheritanceTestSampleA.onEvent(TestBetaEvent) called");
+		}
+
+		public void onEvent(Event event) {
+			fail("InheritanceTestSampleA.onEvent(Event) called");
+		}
+	}
+
+	static class InheritanceTestSampleB extends InheritanceTestSampleA {
+		@Override
+		public void onEvent(Event event) {
+			fail("InheritanceTestSampleB.onEvent(Event) called");
+		}
+	}
+
+	static class InheritanceTestSampleC extends InheritanceTestSampleB {
+		@Override
+		public void onEvent(TestBetaEvent event) {
+			fail("InheritanceTestSampleC.onEvent(TestBetaEvent) called");
+		}
+	}
+}

--- a/src/test/java/me/coley/event/EventBusBenchmark.java
+++ b/src/test/java/me/coley/event/EventBusBenchmark.java
@@ -50,7 +50,7 @@ public class EventBusBenchmark {
 
 	static class MyListener {
 		@Listener
-		public void onEvent(TestAlphaEvent event) {
+		public void onAlphaEvent(TestAlphaEvent event) {
 			event.id++;
 		}
 	}

--- a/src/test/java/me/coley/event/EventBusBenchmark.java
+++ b/src/test/java/me/coley/event/EventBusBenchmark.java
@@ -7,6 +7,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -33,8 +34,13 @@ public class EventBusBenchmark {
 	@Setup
 	public void setup() {
 		this.bus = new EventBus();
-		this.bus.subscribe(this);
+		this.bus.subscribe(new MyListener(), MethodHandles.lookup());
 		this.event = new TestAlphaEvent();
+	}
+
+	@TearDown
+	public void tearDown() {
+		if (event.id == 0) throw new RuntimeException("listener wasn't being called!");
 	}
 
 	@Benchmark
@@ -42,8 +48,10 @@ public class EventBusBenchmark {
 		bus.post(event);
 	}
 
-	@Listener
-	public void onEvent(TestAlphaEvent event) {
-		event.id++;
+	static class MyListener {
+		@Listener
+		public void onEvent(TestAlphaEvent event) {
+			event.id++;
+		}
 	}
 }

--- a/src/test/java/me/coley/event/EventBusBenchmark.java
+++ b/src/test/java/me/coley/event/EventBusBenchmark.java
@@ -1,6 +1,7 @@
 package me.coley.event;
 
-import me.coley.event.testevent.TestAlphaEvent;
+import me.coley.event.testevent.TestBetaEvent;
+import me.coley.event.testevent.TestDeltaEvent;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -28,14 +29,22 @@ public class EventBusBenchmark {
 		new Runner(opt).run();
 	}
 
-	private EventBus bus;
-	private TestAlphaEvent event;
+	private EventBus bus1;
+	private EventBus bus2;
+	private TestDeltaEvent event;
 
 	@Setup
 	public void setup() {
-		this.bus = new EventBus();
-		this.bus.subscribe(new MyListener(), MethodHandles.lookup());
-		this.event = new TestAlphaEvent();
+		final MethodHandles.Lookup lookup = MethodHandles.lookup();
+		this.bus1 = new EventBus();
+		this.bus1.subscribe(MyListener.INSTANCE, lookup);
+		this.bus1.subscribe(MyListener2.INSTANCE, lookup);
+
+		this.bus2 = new EventBus();
+		this.bus2.subscribe(MyListener.INSTANCE, lookup);
+		this.bus2.subscribe(MyCommonTypeListener.INSTANCE, lookup);
+
+		this.event = new TestDeltaEvent();
 	}
 
 	@TearDown
@@ -45,12 +54,37 @@ public class EventBusBenchmark {
 
 	@Benchmark
 	public void post() {
-		bus.post(event);
+		bus1.post(event);
+	}
+
+	@Benchmark
+	public void post_commontype() {
+		bus2.post(event);
 	}
 
 	static class MyListener {
+		static final MyListener INSTANCE = new MyListener();
+
 		@Listener
-		public void onAlphaEvent(TestAlphaEvent event) {
+		public void onDeltaEvent(TestDeltaEvent event) {
+			event.id++;
+		}
+	}
+
+	static class MyListener2 {
+		static final MyListener2 INSTANCE = new MyListener2();
+
+		@Listener
+		public void onDeltaEvent(TestDeltaEvent event) {
+			event.id++;
+		}
+	}
+
+	static class MyCommonTypeListener {
+		static final MyCommonTypeListener INSTANCE = new MyCommonTypeListener();
+
+		@Listener
+		public void onBetaEvent(TestBetaEvent event) {
 			event.id++;
 		}
 	}

--- a/src/test/java/me/coley/event/EventBusTest.java
+++ b/src/test/java/me/coley/event/EventBusTest.java
@@ -41,10 +41,6 @@ public class EventBusTest {
 		marker.assertMarkedOnce("%s received", TestAlphaEvent.class);
 		marker.assertUnmarked("%s received before post", TestBetaEvent.class);
 		bus.post(new TestBetaEvent());
-		bus.post(new TestGammaEvent());
-		bus.post(new TestDeltaEvent());
-		bus.post(new TestEpsilonEvent());
-		bus.post(new TestZetaEvent());
 		marker.assertMarkedOnce("%s received", TestBetaEvent.class);
 		marker.resetAll();
 
@@ -130,6 +126,15 @@ public class EventBusTest {
 		marker.assertMarkedExactly(null, new Class[]{
 				TestGammaEvent.class, TestEpsilonEvent.class, TestZetaEvent.class
 		});
+	}
+
+	@Test
+	public void testInheritedListener() {
+		new MyListenerImpl();
+		bus.post(new TestAlphaEvent());
+		bus.post(new TestBetaEvent());
+		marker.assertMarkedNTimes("%s received two times", TestAlphaEvent.class, 2);
+		marker.assertMarkedNTimes("%s received", TestBetaEvent.class, 2);
 	}
 
 	@Test
@@ -257,6 +262,37 @@ public class EventBusTest {
 
 		@Listener
 		private void privateListener(Event event) {
+			marker.mark(event.getClass());
+		}
+	}
+
+	abstract class AbstractMyListener {
+		{
+			bus.subscribe(this, MethodHandles.lookup().in(getClass()));
+		}
+
+		@Listener
+		protected abstract void onAlphaEvent(TestAlphaEvent event);
+
+		@Listener
+		private void onBetaEvent(TestBetaEvent event) {
+			marker.mark(TestBetaEvent.class);
+		}
+
+		@Listener
+		public void onAllEvent(Event event) {
+			// do nothing
+		}
+	}
+
+	class MyListenerImpl extends AbstractMyListener {
+		@Override
+		protected void onAlphaEvent(TestAlphaEvent event) {
+			marker.mark(TestAlphaEvent.class);
+		}
+
+		@Override
+		public void onAllEvent(Event event) {
 			marker.mark(event.getClass());
 		}
 	}

--- a/src/test/java/me/coley/event/EventBusTest.java
+++ b/src/test/java/me/coley/event/EventBusTest.java
@@ -290,7 +290,7 @@ public class EventBusTest {
 
 		@Listener
 		public void onAllEvent(Event event) {
-			// do nothing
+			fail("onAllEvent() is overrode by MyListenerImpl, this method shouldn't be called");
 		}
 	}
 

--- a/src/test/java/me/coley/event/EventBusTest.java
+++ b/src/test/java/me/coley/event/EventBusTest.java
@@ -243,6 +243,11 @@ public class EventBusTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
+	public void testEmptyListener() {
+		bus.subscribe(new Object());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
 	public void testIllegalListener1() throws ReflectiveOperationException {
 		Object object = new Object() {
 			@Listener

--- a/src/test/java/me/coley/event/EventMarker.java
+++ b/src/test/java/me/coley/event/EventMarker.java
@@ -2,10 +2,7 @@ package me.coley.event;
 
 import org.junit.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -13,6 +10,8 @@ import java.util.stream.Stream;
 import static org.junit.Assert.*;
 
 /**
+ * Test helper.
+ *
  * @author Andy Li
  */
 public class EventMarker<T> {
@@ -28,13 +27,19 @@ public class EventMarker<T> {
 	}
 
 	public void mark(T subject) {
-		if (isUnmarked(subject)) {
-			marks.add(subject);
-		}
+		marks.add(subject);
 	}
 
 	public boolean isMarked(T subject) {
 		return marks.contains(subject);
+	}
+
+	public int getMarkedTimes(T subject) {
+		return Collections.frequency(marks, subject);
+	}
+
+	public boolean isMarkedNTimes(T subject, int expectedCount) {
+		return getMarkedTimes(subject) == expectedCount;
 	}
 
 	public boolean isMarkedOnce(T subject) {
@@ -43,7 +48,7 @@ public class EventMarker<T> {
 			if (Objects.equals(mark, subject)) {
 				if (!result) {  // first occurrence
 					result = true;
-				} else {       // secound occurrence
+				} else {        // secound occurrence
 					return false;
 				}
 			}
@@ -64,7 +69,12 @@ public class EventMarker<T> {
 	}
 
 	public void assertMarkedOnce(String message, T subject) {
-		assertTrue(message, subject, isMarkedOnce(subject));
+		assertMarkedNTimes(message, subject, 1);
+	}
+
+	public void assertMarkedNTimes(String message, T subject, int expectedCount) {
+		if (message.contains("%s")) message = message.replace("%s", toStringFunction.apply(subject));
+		assertEquals(message, expectedCount, Collections.frequency(marks, subject));
 	}
 
 	public void assertUnmarked(String message, T subject) {

--- a/src/test/java/me/coley/event/EventMarker.java
+++ b/src/test/java/me/coley/event/EventMarker.java
@@ -30,6 +30,10 @@ public class EventMarker<T> {
 		marks.add(subject);
 	}
 
+	public List<T> getMarks() {
+		return marks;
+	}
+
 	public boolean isMarked(T subject) {
 		return marks.contains(subject);
 	}

--- a/src/test/java/me/coley/event/PackageListener.java
+++ b/src/test/java/me/coley/event/PackageListener.java
@@ -14,4 +14,8 @@ class PackageListener {
 	void packageListener(Event event) {
 		marker.mark(event.getClass());
 	}
+
+	static class MemberClass {
+		public void foo() { }
+	}
 }


### PR DESCRIPTION
### Changes
* Support overridden listener methods as mentioned in #2.
Example: https://gist.github.com/andylizi/5f04cee61b9cf6a520e500520f901a1c
* Fix priority when involving supertype listener method.
* Throws an exception when subscribing object without any listener methods.
* Fix a huge bug that rendered the whole benchmark process meaningless.
Here's the actual benchmark result:
![benchmark](https://user-images.githubusercontent.com/12008103/46865279-8857e500-ce4f-11e8-81cb-023888021e8e.png)
* Add [proguard](https://www.guardsquare.com/en/products/proguard) plugin.
* Add more tests.
Current test coverage status:

| Class | Method | Line |
| --- | --- | --- |
| EventBus | 79.5% (31/39) | 84.6% (126/149) |
| AccessHelper |  94.7% (18/19) | 71.9% (100/139) |

